### PR TITLE
fix: fix translation keys and missing locale strings

### DIFF
--- a/server/locales/en.js
+++ b/server/locales/en.js
@@ -51,8 +51,12 @@ export default {
         },
         edit: {
           header: 'Edit article',
-          submit: 'Update'
-        }
+          submit: 'Update',
+        },
+        new: {
+          header: 'New article',
+          submit: 'Create',
+        },
       },
 
       welcome: {

--- a/server/locales/ru.js
+++ b/server/locales/ru.js
@@ -26,6 +26,18 @@ export default {
     },
     views: {
       article: {
+        create: {
+          success: 'Статья создана',
+          error: 'Не удалось создать статью',
+        },
+        edit: {
+          success: 'Статья обновлена',
+          error: 'Не удалось обновить статью',
+        },
+        delete: {
+          success: 'Статья удалена',
+          error: 'Не удалось удалить статью',
+        },
         content: {
           placeholder: 'Введите содержимое статьи',
         },
@@ -45,9 +57,9 @@ export default {
           submit: 'Обновить',
         },
         new: {
-          header: 'New Article',
-          submit: 'Create'
-        }
+          header: 'Новая статья',
+          submit: 'Создать',
+        },
       },
       welcome: {
         index: {

--- a/server/views/articles/index.pug
+++ b/server/views/articles/index.pug
@@ -10,7 +10,7 @@ block content
         th= t('views.articles.index.id')
         th= t('views.articles.index.title')
         th= t('views.articles.index.createdAt')
-        th= t('actions')
+        th= t('views.articles.index.actions')
 
     tbody
       each article in articles

--- a/server/views/articles/new.pug
+++ b/server/views/articles/new.pug
@@ -7,7 +7,7 @@ block content
   +formFor()(action=route('articles') method='post')
     +input(article, 'title', errors)(type="text")
     +textarea(article, 'content', errors)(
-      placeholder=t('views.articles.content.placeholder')
+      placeholder=t('views.article.content.placeholder')
       class="h-100"
       rows="10"
     )


### PR DESCRIPTION
## Summary

- Added missing flash message keys in `ru.js`: `views.article.create/edit/delete.success/error`
- Fixed English text in Russian locale: `views.articles.new.header` → «Новая статья», `views.articles.new.submit` → «Создать»
- Added missing `views.articles.new.header/submit` to `en.js`
- Fixed typo in `new.pug`: `views.articles.content.placeholder` → `views.article.content.placeholder`
- Fixed incorrect key in `index.pug`: `t('actions')` → `t('views.articles.index.actions')`

Closes FEEDBACK-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)