### PR TITLE
feat: add a Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
-node_modules/
-dist/
-.env
+node_modules
+dist
+.git
 *.sqlite
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# Сборка отделена от финального образа: better-sqlite3 компилируется из
+# исходников, для этого нужны python3 и g++, и тащить их в рантайм незачем.
+FROM node:26-slim AS builder
+
+# corepack из образов Node 26 убран, поэтому pnpm ставится напрямую. Версия
+# берётся из поля packageManager, чтобы образ и разработка совпадали.
+RUN npm install -g pnpm@11.20.0
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      python3 make g++ \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Зависимости ставятся до копирования кода, чтобы слой с ними переиспользовался
+# и не пересобирался на каждую правку исходников.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+RUN pnpm run build
+
+FROM node:26-slim
+
+# make нужен в рантайме: команды приложения живут в Makefile.
+RUN apt-get update && apt-get install -y --no-install-recommends make \
+  && rm -rf /var/lib/apt/lists/* \
+  && npm install -g pnpm@11.20.0
+
+WORKDIR /app
+COPY --from=builder /app /app
+
+# Порт не задаётся: fastify-cli по умолчанию слушает 3000, и на этот порт
+# рассчитан урок docker_basics_course/600-network, где контейнер запускают
+# как `docker run -p 8080:3000`.
+#
+# Адрес обязателен: на 127.0.0.1 сервер внутри контейнера снаружи недоступен,
+# ровно об этом урок и рассказывает.
+#
+# Флаг -o обязателен тоже: без него fastify-cli не читает экспорт `options` из
+# плагина и регистрирует его дважды, падая с «Route with name root already
+# registered».
+CMD ["pnpm", "exec", "fastify", "start", "-a", "0.0.0.0", "-l", "info", "-P", "-o", "server/plugin.js"]


### PR DESCRIPTION
`docker_basics_course/600-network` asks students to run `hexletcomponents/js-fastify-blog`, but this repository had no Dockerfile, so the published image could not be rebuilt from current source. It still queries an `Articles` table with a `name` column — a schema this code abandoned long before the move to Drizzle.

Two-stage build: `better-sqlite3` compiles from source and its toolchain has no place in the runtime image.

Two details are deliberate and both are load-bearing for that lesson:

- **No port is set.** fastify-cli defaults to 3000, which is what the lesson tells students to map: `docker run -p 8080:3000`.
- **`-a 0.0.0.0`**, without which the server is unreachable from outside the container — the exact failure the lesson is about.

`-o` is also required: without it fastify-cli skips the `options` export and registers the plugin twice, dying with `Route with name root already registered`.

Verified with the lesson's own command: the blog answers on localhost:8080 and an article created through the form comes back in the list.

**Note:** this only makes the image buildable. Republishing `hexletcomponents/js-fastify-blog` is a separate step and would change what students pull, so I have not added a publish workflow.