### PR TITLE
chore: drop the leftover .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-node-options=--no-warnings --experimental-vm-modules


### PR DESCRIPTION
`.npmrc` carried `node-options=--experimental-vm-modules`, which jest needed to run ESM tests. The runner is vitest now and needs nothing, so the file only described a tool this repository no longer has.

It was doubly dead: `node-options` is an npm setting, and pnpm does not apply it when running scripts, so it had already stopped taking effect at the pnpm migration.

`make test` and `make lint` pass without it.